### PR TITLE
Add setup.py and systemd service

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-recursive-include sumochip/config *
-recursive-include sumochip/templates *
-recursive-include sumochip/static *
+include sumochip.service
+graft sumochip

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+recursive-include sumochip/config *
+recursive-include sumochip/templates *
+recursive-include sumochip/static *

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name = "sumochip",
-    version = "1.1",
+    version = "1.1.1",
     author = u"Lauri Võsandi",
     author_email = "lauri.vosandi@gmail.com",
     description = "SumoCHIP is an extremely low-budget robotics platform based on CHIP single-board computer",
@@ -33,4 +33,7 @@ setup(
         'Programming Language :: Python :: 2',
         "Programming Language :: Python :: 2.7",
     ],
+    data_files=[
+        ("lib/systemd/system", ["sumochip.service"])
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+from setuptools import setup
+
+setup(
+    name = "sumochip",
+    version = "1.1",
+    author = u"Lauri Võsandi",
+    author_email = "lauri.vosandi@gmail.com",
+    description = "SumoCHIP is an extremely low-budget robotics platform based on CHIP single-board computer",
+    license = "MIT",
+    keywords = "sumorobot robot nextthingco getchip allwinner arm python flask",
+    url = "http://github.com/laurivosandi/sumochip",
+    packages=[
+        "sumochip",
+    ],
+    long_description="SumoCHIP is an extremely low-budget robotics platform based on CHIP single-board computer",
+    install_requires=[
+        "axp209",
+        "chip-io",
+        "flask",
+        "flask-sockets"
+    ],
+    include_package_data = True,
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Environment :: Console",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python",
+        'Programming Language :: Python :: 2',
+        "Programming Language :: Python :: 2.7",
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "flask-sockets"
     ],
     include_package_data = True,
+    entry_points={'console_scripts': ['sumochip_web = sumochip.webapp:main', 'sumochip_test = sumochip.sumorobot:main']},
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",

--- a/sumochip.service
+++ b/sumochip.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=SumoCHIP web interface
+Documentation=https://github.com/laurivosandi/sumochip
+# Don't run without a config file
+AssertPathExists=/etc/sumorobot/sumorobot.ini
+
+[Service]
+# Note: setting PYTHONUNBUFFERED is necessary to see the output of this service in the journal
+# See https://docs.python.org/2/using/cmdline.html#envvar-PYTHONUNBUFFERED
+Environment=PYTHONUNBUFFERED=true
+
+# By default python scripts are installed under /usr/local/bin
+ExecStart=/usr/local/bin/sumochip_web
+
+# Make it as realtime as possible
+#Nice=-20
+#IOSchedulingClass=realtime
+#IOSchedulingPriority=0
+#CPUSchedulingPolicy=rr
+#CPUSchedulingPriority=99
+
+# In anycase try to restart the service
+Restart=on-failure
+# Sleep 3s before restart
+RestartSec=3s
+
+[Install]
+WantedBy=multi-user.target

--- a/sumochip/README.md
+++ b/sumochip/README.md
@@ -9,22 +9,45 @@
 ```
 apt update
 apt full-upgrade
-apt install git python-pip python-dev
-pip install Flask Flask-Sockets CHIP-IO axp209
-git clone https://github.com/artizirk/sumochip
+apt install git python-pip python-dev python-systemd
+```
+
+Install stable release
+
+```
+pip install sumochip
+```
+
+or install git version
+
+```
+pip install git+https://github.com/laurivosandi/sumochip
 ```
 
 5. Configure sumorobot software
 
 ```
-cd ~/sumochip/sumochip
-rm sumorobot.ini
-ln -s config/sumochip_v1.1.ini sumorobot.ini
+mkdir -p /etc/sumorobot
+cp `python -c "import os, sumochip; print(os.path.dirname(os.path.realpath(sumochip.__file__)))"`/config/sumochip_v1.1.ini /etc/sumorobot/sumorobot.ini
 ```
 
 6. Run self test
 
 ```
-cd ~/sumochip/sumochip
-python sumorobot.py
+sumochip_test
+```
+
+7. Start the web interface
+
+From terminal
+
+```
+sumochip_web
+```
+
+Or start and optionaly enable autostart of systemd service
+
+```
+systemctl start sumochip
+systemctl enable sumochip
 ```

--- a/sumochip/sumorobot.py
+++ b/sumochip/sumorobot.py
@@ -498,7 +498,7 @@ def self_test(s):
 
 
     print("motor_left test")
-    for x in range(-100, 100, 1):
+    for x in range(-100, 100, 2):
         s.motor_left.speed = x/100.0
         print(x, end="   \r")
         sys.stdout.flush()
@@ -507,7 +507,7 @@ def self_test(s):
     s.motor_left.speed = 0
 
     print("motor_right test")
-    for x in range(-100, 100, 1):
+    for x in range(-100, 100, 2):
         s.motor_right.speed = x/100.0
         print(x, end="   \r")
         sys.stdout.flush()
@@ -515,6 +515,16 @@ def self_test(s):
     print()
     s.motor_left.speed = 0
 
+
+    print("sumorobot.forward()")
+    s.forward()
+    sleep(1)
+    s.stop()
+
+    print("sumorobot.back()")
+    s.back()
+    sleep(1)
+    s.stop()
 
     print("Entering play mode")
     while True:
@@ -555,8 +565,7 @@ def self_test(s):
 
         sleep(0.01)
 
-
-if __name__ == "__main__":
+def main():
     try:
         s = Sumorobot()
         self_test(s)
@@ -567,3 +576,6 @@ if __name__ == "__main__":
         s.red_led.value = 1
         s.yellow_led.value = 1
         s.green_led.value = 1
+
+if __name__ == "__main__":
+    main()

--- a/sumochip/webapp.py
+++ b/sumochip/webapp.py
@@ -6,6 +6,7 @@ from threading import Thread
 from time import sleep
 import imp
 import json
+import os
 
 codeTemplate = """
 from threading import Thread
@@ -109,9 +110,16 @@ def command(ws):
             codeBytecode = compile(fullCodeText, "<SumorobotCode>", "exec")
             print('Saved')
 
-if __name__ == '__main__':
-    print("Started server")
+
+def main():
     from gevent import pywsgi
     from geventwebsocket.handler import WebSocketHandler
-    server = pywsgi.WSGIServer(('0.0.0.0', 5001), app, handler_class=WebSocketHandler)
+    ip, port = ('0.0.0.0', 5001)
+    if os.getuid() == 0:
+        port = 80
+    server = pywsgi.WSGIServer((ip, port), app, handler_class=WebSocketHandler)
+    print("Starting server at http://{}:{}".format(ip, port))
     server.serve_forever()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Sumochip can now be installed using `pip install sumochip` although config file still has to be copied manualy to /etc/sumorobot because the new Wheel format that python pacakges use do not support post_install scripts so we can't really detect if the package is being installed to a virtualenv, as a user package or as a global system wide package. For that we need to create a proper .deb package.

There is also a sumochip.service file for systemd that by default is installed to sys.prefix/lib/systemd/system witch translates under debian to /usr/local/lib/systemd/system.
`systemctl start sumochip` will start the sumochip web interface on port 80 and `systemctl enable sumochip` will autostart the webinterface on boot. I also experimented with some realtime flags but those will crash the chip if enabled. 
